### PR TITLE
Cargo.toml: rm unused slab dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ license = "Apache-2.0/MIT"
 
 [dependencies]
 pin-project = "1.0"
-slab = "0.4.2"
 async-std = { version = "1.12.0", optional = true }
 futures = "0.3.15"
 tokio = {version = "1.0", features = ["rt-multi-thread", "macros", "sync"], optional = true}


### PR DESCRIPTION
I saw on lib.rs that this project was using **slab**.

I wondered why, so I checked the code.

I see it's not actually used anywhere. 

Confirmed with `cargo machete` and tested with `cargo test --all-features`.