### PR TITLE
Remove feature gates, make Scope stateful

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ number (> ~1K) of I/O futures, or a few CPU heavy futures.
 ## Usage
 
 The API is meant to be a minimal wrapper around efficient
-executors. Users **must use** either "use-async-std", or the
-"use-tokio" feature gates, to obtain a usable scope type.
-These gates provide `TokioScope` and `AsyncScope` that
-support spawning, and blocking. See
+executors. Users may use "use-async-std", or the
+"use-tokio" features, to obtain a specific global executor implementation.
+These features provide `TokioScope` and `AsyncScope` that
+support spawning, and blocking.
+However, none of those features are necessary -
+you may freely implement your own executor. See
 [docs.rs](https://docs.rs/async-scoped) for detailed
 documentation.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! ``` rust, ignore
 //! pub unsafe fn scope<'a, T: Send + 'static,
-//!              F: FnOnce(&mut Scope<'a, T>)>(f: F)
+//!              F: FnOnce(&mut TokioScope<'a, T>)>(f: F)
 //!              -> impl Stream {
 //!     // ...
 //! }
@@ -64,13 +64,12 @@
 //!
 //! ## Executor Selection
 //!
-//! Users **must use** either "use-async-std", or the
-//! "use-tokio" feature gates, to obtain a usable scope
-//! type. These gates provide [`TokioScope`] and
-//! [`AsyncScope`] that support spawning, and blocking. Here
-//! is a run-down of key differences between the two
-//! runtimes.
+//! Users may use "use-async-std", or the
+//! "use-tokio" features to enable specific executor implementations.
+//! Those are not necessary, you may freely implement traits `Spawner`, `Blocker`, etc for your own
+//! runtime. Just ensure you follow the safety idea.
 //!
+//! Some notes on default implementations:
 //! 1. [`AsyncScope`] may run into a dead-lock if used in
 //! deep recursions (depth > #num-cores / 2).
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! async fn scoped_futures() {
 //!     let not_copy = String::from("hello world!");
 //!     let not_copy_ref = &not_copy;
-//!     let (foo, outputs) = async_scoped::AsyncScope::scope_and_block(|s| {
+//!     let (foo, outputs) = async_scoped::AsyncStdScope::scope_and_block(|s| {
 //!         for _ in 0..10 {
 //!             let proc = || async {
 //!                 assert_eq!(not_copy_ref, "hello world!");
@@ -147,20 +147,14 @@ mod utils;
 mod scoped;
 pub use scoped::Scope;
 
-cfg_async_std! {
-    pub type AsyncScope<'a, T> = scoped::Scope<'a, T, spawner::use_async_std::AsyncStd>;
-    pub use spawner::use_async_std::AsyncStd;
-}
+#[cfg(feature = "use-tokio")]
+pub type TokioScope<'a, T> = Scope<'a, T, spawner::use_tokio::Tokio>;
 
-cfg_tokio!{
-    pub type TokioScope<'a, T> = scoped::Scope<'a, T, spawner::use_tokio::Tokio>;
-    pub use spawner::use_tokio::Tokio;
-}
+#[cfg(feature = "use-async-std")]
+pub type AsyncStdScope<'a, T> = Scope<'a, T, spawner::use_async_std::AsyncStd>;
 
-mod spawner;
+pub mod spawner;
 mod usage;
 
-cfg_any_spawner!{
-    #[cfg(test)]
-    mod tests;
-}
+#[cfg(test)]
+mod tests;

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -2,31 +2,33 @@ use futures::Future;
 
 pub trait Spawner<T> {
     type FutureOutput;
-    type SpawnHandle: Future<Output=Self::FutureOutput> + Send;
-    fn spawn<F: Future<Output=T> + Send + 'static>(f: F) -> Self::SpawnHandle;
+    type SpawnHandle: Future<Output = Self::FutureOutput> + Send;
+    fn spawn<F: Future<Output = T> + Send + 'static>(&self, f: F) -> Self::SpawnHandle;
 }
 
 pub trait FuncSpawner<T> {
     type FutureOutput;
     type SpawnHandle: Future<Output = Self::FutureOutput> + Send;
-    fn spawn_func<F: FnOnce() -> T + Send + 'static>(f: F) -> Self::SpawnHandle;
+    fn spawn_func<F: FnOnce() -> T + Send + 'static>(&self, f: F) -> Self::SpawnHandle;
 }
 
 pub trait Blocker {
-    fn block_on<T, F: Future<Output=T>>(f: F) -> T;
+    fn block_on<T, F: Future<Output = T>>(&self, f: F) -> T;
 }
 
 #[cfg(feature = "use-async-std")]
 pub mod use_async_std {
     use super::*;
-    use async_std::task::{spawn, block_on, spawn_blocking, JoinHandle};
+    use async_std::task::{block_on, spawn, spawn_blocking, JoinHandle};
+
+    #[derive(Default)]
     pub struct AsyncStd;
 
     impl<T: Send + 'static> Spawner<T> for AsyncStd {
         type FutureOutput = T;
         type SpawnHandle = JoinHandle<T>;
 
-        fn spawn<F: Future<Output=T> + Send + 'static>(f: F) -> Self::SpawnHandle {
+        fn spawn<F: Future<Output = T> + Send + 'static>(&self, f: F) -> Self::SpawnHandle {
             spawn(f)
         }
     }
@@ -34,29 +36,30 @@ pub mod use_async_std {
         type FutureOutput = T;
         type SpawnHandle = JoinHandle<T>;
 
-        fn spawn_func<F: FnOnce() -> T + Send + 'static>(f: F) -> Self::SpawnHandle {
+        fn spawn_func<F: FnOnce() -> T + Send + 'static>(&self, f: F) -> Self::SpawnHandle {
             spawn_blocking(f)
         }
     }
     impl Blocker for AsyncStd {
-        fn block_on<T, F: Future<Output=T>>(f: F) -> T {
+        fn block_on<T, F: Future<Output = T>>(&self, f: F) -> T {
             block_on(f)
         }
     }
 }
 
-
 #[cfg(feature = "use-tokio")]
 pub mod use_tokio {
     use super::*;
     use tokio::task as tokio_task;
+
+    #[derive(Default)]
     pub struct Tokio;
 
     impl<T: Send + 'static> Spawner<T> for Tokio {
         type FutureOutput = Result<T, tokio_task::JoinError>;
         type SpawnHandle = tokio_task::JoinHandle<T>;
 
-        fn spawn<F: Future<Output=T> + Send + 'static>(f: F) -> Self::SpawnHandle {
+        fn spawn<F: Future<Output = T> + Send + 'static>(&self, f: F) -> Self::SpawnHandle {
             tokio_task::spawn(f)
         }
     }
@@ -65,13 +68,13 @@ pub mod use_tokio {
         type FutureOutput = Result<T, tokio_task::JoinError>;
         type SpawnHandle = tokio_task::JoinHandle<T>;
 
-        fn spawn_func<F: FnOnce() -> T + Send + 'static>(f: F) -> Self::SpawnHandle {
+        fn spawn_func<F: FnOnce() -> T + Send + 'static>(&self, f: F) -> Self::SpawnHandle {
             tokio_task::spawn_blocking(f)
         }
     }
 
     impl Blocker for Tokio {
-        fn block_on<T, F: Future<Output=T>>(f: F) -> T {
+        fn block_on<T, F: Future<Output = T>>(&self, f: F) -> T {
             tokio_task::block_in_place(|| {
                 tokio::runtime::Builder::new_current_thread()
                     .build()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,7 @@ macro_rules! test_fixtures {
 }
 
 cfg_async_std! {
-    use crate::AsyncScope as Scope;
+    use crate::AsyncStdScope as Scope;
 
     fn future_value<T>(v: T) -> T {
         v
@@ -78,7 +78,7 @@ test_fixtures! {
         let stream = unsafe {
             use async_std::future::{timeout, pending};
             use std::time::Duration;
-            let mut s = Scope::create();
+            let mut s = Scope::create(Default::default());
             for _ in 0..10 {
                 let proc = || async move {
                     assert_eq!(not_copy_ref, "hello world!");
@@ -254,7 +254,7 @@ test_fixtures! {
     // This test is resource consuming and ignored by default
     #[ignore]
     async fn backpressure() {
-        let mut s = unsafe { Scope::create() };
+        let mut s = unsafe { Scope::create(Default::default()) };
         let limit = 0x10;
         for i in 0..0x100 {
             s.spawn(async {


### PR DESCRIPTION
closes #15 

As said in the issue, this is an attempt to adapt crate so it could be used with ANY user-supplied executor