### PR TITLE
make TokioSpawner completely stateful

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,10 +147,10 @@ mod scoped;
 pub use scoped::Scope;
 
 #[cfg(feature = "use-tokio")]
-pub type TokioScope<'a, T> = Scope<'a, T, spawner::use_tokio::Tokio>;
+pub type TokioScope<'a, T> = Scope<'a, T, spawner::use_tokio::TokioSpawner>;
 
 #[cfg(feature = "use-async-std")]
-pub type AsyncStdScope<'a, T> = Scope<'a, T, spawner::use_async_std::AsyncStd>;
+pub type AsyncStdScope<'a, T> = Scope<'a, T, spawner::use_async_std::AsyncStdSpawner>;
 
 pub mod spawner;
 mod usage;

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -25,9 +25,9 @@ pub mod use_async_std {
     use async_std::task::{block_on, spawn, spawn_blocking, JoinHandle};
 
     #[derive(Default)]
-    pub struct AsyncStd;
+    pub struct AsyncStdSpawner;
 
-    unsafe impl<T: Send + 'static> Spawner<T> for AsyncStd {
+    unsafe impl<T: Send + 'static> Spawner<T> for AsyncStdSpawner {
         type FutureOutput = T;
         type SpawnHandle = JoinHandle<T>;
 
@@ -35,7 +35,7 @@ pub mod use_async_std {
             spawn(f)
         }
     }
-    unsafe impl<T: Send + 'static> FuncSpawner<T> for AsyncStd {
+    unsafe impl<T: Send + 'static> FuncSpawner<T> for AsyncStdSpawner {
         type FutureOutput = T;
         type SpawnHandle = JoinHandle<T>;
 
@@ -43,7 +43,7 @@ pub mod use_async_std {
             spawn_blocking(f)
         }
     }
-    unsafe impl Blocker for AsyncStd {
+    unsafe impl Blocker for AsyncStdSpawner {
         fn block_on<T, F: Future<Output = T>>(&self, f: F) -> T {
             block_on(f)
         }
@@ -53,37 +53,44 @@ pub mod use_async_std {
 #[cfg(feature = "use-tokio")]
 pub mod use_tokio {
     use super::*;
-    use tokio::task as tokio_task;
+    use tokio::{runtime::Handle, task as tokio_task};
 
-    #[derive(Default)]
-    pub struct Tokio;
+    pub struct TokioSpawner(Handle);
 
-    unsafe impl<T: Send + 'static> Spawner<T> for Tokio {
+    impl TokioSpawner {
+        pub fn new(rt_handle: Handle) -> Self {
+            Self(rt_handle)
+        }
+    }
+
+    // By default, `TokioSpawner` operates on global runtime.
+    impl Default for TokioSpawner {
+        fn default() -> Self {
+            Self(Handle::current())
+        }
+    }
+
+    unsafe impl<T: Send + 'static> Spawner<T> for TokioSpawner {
         type FutureOutput = Result<T, tokio_task::JoinError>;
         type SpawnHandle = tokio_task::JoinHandle<T>;
 
         fn spawn<F: Future<Output = T> + Send + 'static>(&self, f: F) -> Self::SpawnHandle {
-            tokio_task::spawn(f)
+            self.0.spawn(f)
         }
     }
 
-    unsafe impl<T: Send + 'static> FuncSpawner<T> for Tokio {
+    unsafe impl<T: Send + 'static> FuncSpawner<T> for TokioSpawner {
         type FutureOutput = Result<T, tokio_task::JoinError>;
         type SpawnHandle = tokio_task::JoinHandle<T>;
 
         fn spawn_func<F: FnOnce() -> T + Send + 'static>(&self, f: F) -> Self::SpawnHandle {
-            tokio_task::spawn_blocking(f)
+            self.0.spawn_blocking(f)
         }
     }
 
-    unsafe impl Blocker for Tokio {
+    unsafe impl Blocker for TokioSpawner {
         fn block_on<T, F: Future<Output = T>>(&self, f: F) -> T {
-            tokio_task::block_in_place(|| {
-                tokio::runtime::Builder::new_current_thread()
-                    .build()
-                    .unwrap()
-                    .block_on(f)
-            })
+            tokio_task::block_in_place(|| self.0.block_on(f))
         }
     }
 }


### PR DESCRIPTION
I propose two things in this PR:

1) Make tokio spawner completely stateful, so it could take a handle to custom runtime. This is needed, because we don't want the consumers of library to implement the traits themselves. Instead, after this PR, we would be able to simply allow them to use the default implementation. By default tokio spawner would take global runtime. It also fixes tokio's `block_on` implementation - as it was spawning brand new runtime every call;
2) Add suffixes to `AsyncStd` and `Tokio` spawners(so make them `AsyncStdSpawner` and `TokioSpawner`) for easier end-user experience.

This PR breaks backward-compatibilty by adding suffixes to globally-exposed structures and redesigning `TokioSpawner`.