### PR TITLE
Make scope yield elements in FIFO order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,8 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 
 [package.metadata.docs.rs]
 features = ["use-async-std", "use-tokio"]
+
+[[bench]]
+name = "spawner"
+path = "benches/spawner.rs"
+harness = false

--- a/benches/spawner.rs
+++ b/benches/spawner.rs
@@ -1,0 +1,51 @@
+use std::hint::black_box;
+use futures::future::pending;
+use async_scoped::{
+    Scope,
+    spawner::{Blocker, Spawner},
+};
+
+fn spawn_and_collect<Sp: Spawner<usize> + Blocker>(s: &mut Scope<usize, Sp>) {
+    const INPUT_SIZE: usize = 1000000;
+    const MAX_DELAY: usize = 1 << 8;
+    for i in 0..INPUT_SIZE {
+        let delay = i & MAX_DELAY;
+        s.spawn(async move {
+            let _ = async_std::future::timeout(
+                std::time::Duration::from_millis((MAX_DELAY - delay) as u64),
+                pending::<()>(),
+            ).await;
+            i
+        });
+    }
+}
+
+fn main() {
+    let r = {
+        #[cfg(feature = "async-std")]
+        {
+            // Async-std runtime does not have a straightforward way to configure multi-threaded
+            // runtime: https://docs.rs/async-std/latest/async_std/index.html#runtime-configuration
+            // ASYNC_STD_THREAD_COUNT environment variable must be used to match the Tokio benchmark
+            use async_scoped::AsyncStdScope;
+            let (_, r) = AsyncStdScope::scope_and_block(spawn_and_collect);
+
+            r
+        }
+        #[cfg(feature = "use-tokio")]
+        {
+            use async_scoped::TokioScope;
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(4)
+                .build()
+                .unwrap()
+                .block_on(async move {
+                    let (_, r) = TokioScope::scope_and_block(spawn_and_collect);
+
+                    r
+                })
+        }
+    };
+
+    r.into_iter().for_each(|v| { let _ = black_box(v); })
+}


### PR DESCRIPTION
Using `FuturesUnordered` internally causes `Scope` to returns items out of order, making clients responsible for matching the order of elements sent to `Scope` received from it. This extra bookkeeping along with extra buffering make client's work repetitive and somewhat a duplicate of what `FuturesOrdered` already provides.

Given that `Scope` implements a `Stream`, it seems to be a safe default to return elements back in FIFO order.

Alternatives that could be considered

* Specialization for FIFO - `Scope` can take an optional parameter indicating whether ordering is important. 
* Make `spawn` return a handle that is bound via lifetime to the `Scope` object. Make client responsible for polling that handle and therefore have full control over ordering. Need to prove safety for it.


