### PR TITLE
Avoid blocking on dropping an empty scope

### DIFF
--- a/src/scoped.rs
+++ b/src/scoped.rs
@@ -165,7 +165,7 @@ impl<'a, T, Sp: Spawner<T> + Blocker> Stream for Scope<'a, T, Sp> {
 #[pinned_drop]
 impl<'a, T, Sp: Spawner<T> + Blocker> PinnedDrop for Scope<'a, T, Sp> {
     fn drop(mut self: Pin<&mut Self>) {
-        if !self.done {
+        if !(self.done || self.remaining == 0) {
             let spawner = self.spawner.take().expect("invariant:spawner must be taken only on drop");
             spawner.block_on(async {
                 self.cancel();


### PR DESCRIPTION
There is a difference in drop behavior between scopes that were used to spawn futures and later drained and scopes that were created and never used. In the latter case, there is an unnecessary call to `block_on`.

This change addresses this by checking whether `remaining` is 0 inside `drop`.