### PR TITLE
chore: using "in parallel" in document to be more natural.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ smaller than `'static`.
 While the future combinators such as `for_each_concurrent`
 offer concurrency, they are bundled as a single `Task`
 structure by the executor, and hence are not driven
-parallelly. This can be seen when benchmarking a reasonable
+in parallel. This can be seen when benchmarking a reasonable
 number (> ~1K) of I/O futures, or a few CPU heavy futures.
 
 ## Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! [`for_each_concurrent`][for_each_concurrent] offer
 //! concurrency, they are bundled as a single [`Task`][Task]
 //! structure by the executor, and hence are not driven
-//! parallelly.
+//! in parallel.
 //!
 //! ## Scope API
 //!


### PR DESCRIPTION
Refer [Is using the word "parallelly" grammatically correct?](https://www.quora.com/Is-using-the-word-parallelly-grammatically-correct) Much thanks.